### PR TITLE
GetCurseDuration() scans spellbook for DRUID too

### DIFF
--- a/curses.lua
+++ b/curses.lua
@@ -77,7 +77,7 @@ function curses:LoadCurses()
 end
 
 function curses:GetCurseDuration(curseSpellID)
-	if playerClassName == "WARLOCK" and curses.trackedCurseIds[curseSpellID].rapid_deterioration then
+	if (playerClassName == "WARLOCK" and curses.trackedCurseIds[curseSpellID].rapid_deterioration) or playerClassName == "DRUID" then
 		-- scan spellbook for duration in case they have haste talent
 		local nameRank = curses.trackedCurseIds[curseSpellID].name .. "Rank " .. curses.trackedCurseIds[curseSpellID].rank
 		local spellSlot = curses.trackedCurseNameRanksToSpellSlots[nameRank]


### PR DESCRIPTION
Moonkin T3 changes MF and IS durations
there idol to change duration of bleeds
and it doesn't seem to cause any noticable slowdown so maybe it should become default behaviour for all classes